### PR TITLE
Better detection of service folders to build

### DIFF
--- a/changedetector/changedetector.go
+++ b/changedetector/changedetector.go
@@ -2,12 +2,47 @@ package changedetector
 
 import (
 	"context"
-	"path"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/google/go-github/v30/github"
+	"github.com/spf13/afero"
 	"golang.org/x/oauth2"
+)
+
+var (
+	appFS = afero.NewOsFs() // use this for all OS manipulation so we can mock more easily
+)
+
+var (
+	errGoModNotFound = errors.New("Parent go.mod file not found")
+)
+
+type fileToStatus struct {
+	fileName string
+	status   githubFileChangeStatus
+}
+
+type githubFileChangeStatus string
+
+// a list of github file status changes.
+// not documented in the github API
+var (
+	githubFileChangeStatusCreated  githubFileChangeStatus = "added"
+	githubFileChangeStatusChanged  githubFileChangeStatus = "changed"
+	githubFileChangeStatusModified githubFileChangeStatus = "modified"
+	githubFileChangeStatusRemoved  githubFileChangeStatus = "removed"
+)
+
+// Status is the status of the service
+type Status string
+
+var (
+	StatusCreated Status = "created"
+	StatusUpdated Status = "updated"
+	StatusDeleted Status = "deleted"
 )
 
 func New(ghToken, ghRepo, ghOwner, ghSHA string) *ChangeDetector {
@@ -31,6 +66,8 @@ type ChangeDetector struct {
 }
 
 // List uses the github sha to determine all the changes
+// It returns a list of folders which we think represent services that have changed.
+// For example, if serviceA/main.go and serviceB/handler/handler.go have changed but serviceC/ hasn't it should return serviceA and serviceB
 func (cd *ChangeDetector) List() (map[string]Status, error) {
 	repo := strings.TrimPrefix(cd.githubRepo, cd.githubOwner+"/")
 	commit, _, err := cd.client.Repositories.GetCommit(context.Background(), cd.githubOwner, repo, cd.githubSHA)
@@ -51,84 +88,69 @@ func (cd *ChangeDetector) List() (map[string]Status, error) {
 		})
 	}
 
-	return folderStatuses(filesToStatuses), nil
+	return directoryStatuses(filesToStatuses)
 }
 
-// maps github file change statuses to folders and their deployment status
-// ie. "asim/scheduler/main.go" "removed" will become "asim/scheduler" "deleted"
-func folderStatuses(statuses []fileToStatus) map[string]Status {
-	folders := map[string]Status{}
-	// Prioritize main.go creates and deletes
+// maps github file change statuses to directories (or actually services) and their deployment status
+// ie. "asim/scheduler/main.go" "removed" => "asim/scheduler" "deleted"
+// "serviceA/handler/handler.go" "modified" => "serviceA" "updafed"
+func directoryStatuses(statuses []fileToStatus) (map[string]Status, error) {
+	dirs := map[string]Status{}
+
+	// Logic. Assume that go.mod is the root of the service or thing to be built. Note not using main.go because sometimes people like to use something else
+	// For every changed file traverse up to find the direct parent go.mod file and record the dir
+	// Dedupe so you only build a dir once.
+	// If go.mod is created or deleted we record that as the service being created or deleted. Everything else is assumed an update
+
 	for _, status := range statuses {
 		fname := status.fileName
 		status := status.status
-		if !strings.HasSuffix(fname, "main.go") {
-			continue
-		}
-		fold := path.Dir(fname)
+		_, fileName := filepath.Split(fname)
 
-		_, exists := folders[fold]
-		if exists {
+		dir, err := findParentGoModDir(fname)
+		if err != nil && err == errGoModNotFound {
+			// assume that go mod was deleted, skip
 			continue
 		}
-		if status == "added" {
-			folders[fold] = StatusCreated
-		} else if status == "removed" {
-			folders[fold] = StatusDeleted
+		if err != nil {
+			return nil, err
 		}
-
-	}
-	// continue with normal file changes for service updates
-	for _, status := range statuses {
-		fname := status.fileName
-		// All service files are inside folders,
-		// so any file in the top folder can be safely ignored.
-		if !strings.Contains(fname, "/") {
-			continue
-		}
-		folds := topFolders(fname)
-		for _, fold := range folds {
-			_, exists := folders[fold]
-			if exists {
-				continue
+		if fileName == "go.mod" {
+			fmt.Printf("Go mod Status is %s\n", status)
+			if status == githubFileChangeStatusCreated {
+				dirs[dir] = StatusCreated
+			} else if status == githubFileChangeStatusRemoved {
+				dirs[dir] = StatusDeleted
 			}
-			folders[fold] = StatusUpdated
+		}
+		if _, ok := dirs[dir]; !ok {
+			dirs[dir] = StatusUpdated
+		}
+
+	}
+	return dirs, nil
+}
+
+func findParentGoModDir(fileName string) (string, error) {
+	dir, file := filepath.Split(fileName)
+	if len(dir) > 0 {
+		dir = dir[:len(dir)-1]
+	} // clean up by removing any trailing slash
+	if file == "go.mod" {
+		return dir, nil
+	}
+	for {
+		listing, _ := afero.ReadDir(appFS, dir) // ignore error because it would indicate that dir is missing which is OK
+		for _, f := range listing {
+			if f.Name() == "go.mod" {
+				return dir, nil
+			}
+		}
+		dir = filepath.Dir(dir)
+		if dir == "." {
+			break
 		}
 	}
-	return folders
+	return "", errGoModNotFound
+
 }
-
-// from path returns the top level dirs to be deployed
-// ie.
-func topFolders(path string) []string {
-	parts := strings.Split(path, "/")
-	ret := []string{parts[0]}
-	if len(parts) > 2 {
-		ret = append(ret, filepath.Join(parts[0], parts[1]))
-	}
-	return ret
-}
-
-type fileToStatus struct {
-	fileName string
-	status   githubFileChangeStatus
-}
-
-type githubFileChangeStatus string
-
-// a list of github file status changes.
-// not documented in the github API
-var (
-	githubFileChangeStatusCreated  githubFileChangeStatus = "added"
-	githubFileChangeStatusChanged  githubFileChangeStatus = "changed"
-	githubFileChangeStatusModified githubFileChangeStatus = "modified"
-	githubFileChangeStatusRemoved  githubFileChangeStatus = "removed"
-)
-
-type Status string
-
-var (
-	StatusCreated Status = "created"
-	StatusUpdated Status = "updated"
-	StatusDeleted Status = "deleted"
-)

--- a/changedetector/changedetector.go
+++ b/changedetector/changedetector.go
@@ -3,7 +3,6 @@ package changedetector
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -116,7 +115,6 @@ func directoryStatuses(statuses []fileToStatus) (map[string]Status, error) {
 			return nil, err
 		}
 		if fileName == "go.mod" {
-			fmt.Printf("Go mod Status is %s\n", status)
 			if status == githubFileChangeStatusCreated {
 				dirs[dir] = StatusCreated
 			} else if status == githubFileChangeStatusRemoved {

--- a/changedetector/changedetector.go
+++ b/changedetector/changedetector.go
@@ -16,7 +16,7 @@ var (
 )
 
 var (
-	errGoModNotFound = errors.New("Parent go.mod file not found")
+	errGoMainNotFound = errors.New("Parent main.go file not found")
 )
 
 type fileToStatus struct {
@@ -78,7 +78,7 @@ func (cd *ChangeDetector) List() (map[string]Status, error) {
 	for _, v := range commit.Files {
 		// special case. If m3o.yaml is *added* we should build all the things
 		if v.GetFilename() == ".github/workflows/m3o.yaml" && githubFileChangeStatus(v.GetStatus()) == githubFileChangeStatusCreated {
-			return findAllGoModDirs(".")
+			return findAllGoMainDirs(".")
 		}
 
 		// skip files starting with . e.g. ".github"
@@ -95,9 +95,9 @@ func (cd *ChangeDetector) List() (map[string]Status, error) {
 	return directoryStatuses(filesToStatuses)
 }
 
-// findAllGoModDirs records directory of every go.mod file and returns with StatusCreated to force a rebuild of all the things
-func findAllGoModDirs(dirPath string) (map[string]Status, error) {
-	// search for all go.mod files and record their directories
+// findAllGoMainDirs records directory of every main.go file and returns with StatusCreated to force a rebuild of all the things
+func findAllGoMainDirs(dirPath string) (map[string]Status, error) {
+	// search for all main.go files and record their directories
 	ret := map[string]Status{}
 	listing, err := afero.ReadDir(appFS, dirPath)
 	if err != nil {
@@ -105,7 +105,7 @@ func findAllGoModDirs(dirPath string) (map[string]Status, error) {
 	}
 	for _, f := range listing {
 		if f.IsDir() {
-			statuses, err := findAllGoModDirs(dirPath + "/" + f.Name())
+			statuses, err := findAllGoMainDirs(dirPath + "/" + f.Name())
 			if err != nil {
 				return nil, err
 			}
@@ -114,7 +114,7 @@ func findAllGoModDirs(dirPath string) (map[string]Status, error) {
 			}
 			continue
 		}
-		if f.Name() == "go.mod" {
+		if f.Name() == "main.go" {
 			ret[filepath.Clean(dirPath)] = StatusCreated
 		}
 	}
@@ -127,25 +127,25 @@ func findAllGoModDirs(dirPath string) (map[string]Status, error) {
 func directoryStatuses(statuses []fileToStatus) (map[string]Status, error) {
 	dirs := map[string]Status{}
 
-	// Logic. Assume that go.mod is the root of the service or thing to be built. Note not using main.go because sometimes people like to use something else
-	// For every changed file traverse up to find the direct parent go.mod file and record the dir
+	// Logic. Assume that main.go is the root of the service or thing to be built.
+	// For every changed file traverse up to find the direct parent main.go file and record the dir
 	// Dedupe so you only build a dir once.
-	// If go.mod is created or deleted we record that as the service being created or deleted. Everything else is assumed an update
+	// If main.go is created or deleted we record that as the service being created or deleted. Everything else is assumed an update
 
 	for _, status := range statuses {
 		fname := status.fileName
 		status := status.status
 		_, fileName := filepath.Split(fname)
 
-		dir, err := findParentGoModDir(fname)
-		if err != nil && err == errGoModNotFound {
-			// assume that go mod was deleted, skip
+		dir, err := findParentGoMainDir(fname)
+		if err != nil && err == errGoMainNotFound {
+			// assume that go main was deleted, skip
 			continue
 		}
 		if err != nil {
 			return nil, err
 		}
-		if fileName == "go.mod" {
+		if fileName == "main.go" {
 			if status == githubFileChangeStatusCreated {
 				dirs[dir] = StatusCreated
 			} else if status == githubFileChangeStatusRemoved {
@@ -160,16 +160,16 @@ func directoryStatuses(statuses []fileToStatus) (map[string]Status, error) {
 	return dirs, nil
 }
 
-func findParentGoModDir(fileName string) (string, error) {
+func findParentGoMainDir(fileName string) (string, error) {
 	dir, file := filepath.Split(fileName)
 	dir = filepath.Clean(dir)
-	if file == "go.mod" {
+	if file == "main.go" {
 		return dir, nil
 	}
 	for {
 		listing, _ := afero.ReadDir(appFS, dir) // ignore error because it would indicate that dir is missing which is OK
 		for _, f := range listing {
-			if f.Name() == "go.mod" {
+			if f.Name() == "main.go" {
 				return dir, nil
 			}
 		}
@@ -178,6 +178,6 @@ func findParentGoModDir(fileName string) (string, error) {
 			break
 		}
 	}
-	return "", errGoModNotFound
+	return "", errGoMainNotFound
 
 }

--- a/changedetector/changedetector_test.go
+++ b/changedetector/changedetector_test.go
@@ -1,0 +1,128 @@
+package changedetector
+
+import (
+	"path"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFolderStatuses(t *testing.T) {
+
+	tcs := []struct {
+		input      []fileToStatus
+		goModFiles []string // where do the go.mod files live
+		expected   map[string]Status
+	}{
+		{
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/main.go", status: githubFileChangeStatusModified,
+				},
+			},
+			goModFiles: []string{"serviceA/go.mod"},
+			expected:   map[string]Status{"serviceA": StatusUpdated},
+		},
+		{
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/handler/handler.go", status: githubFileChangeStatusModified,
+				},
+			},
+			goModFiles: []string{"serviceA/go.mod"},
+			expected:   map[string]Status{"serviceA": StatusUpdated},
+		},
+		{
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/proto/serviceA/serviceA.pb.go", status: githubFileChangeStatusModified,
+				},
+			},
+			goModFiles: []string{"serviceA/go.mod"},
+			expected:   map[string]Status{"serviceA": StatusUpdated},
+		},
+		{
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/proto/serviceA/serviceA.pb.go", status: githubFileChangeStatusModified,
+				},
+				{
+					fileName: "serviceB/main.go", status: githubFileChangeStatusModified,
+				},
+				{
+					fileName: "serviceB/dao/dao.go", status: githubFileChangeStatusModified,
+				},
+			},
+			goModFiles: []string{"serviceA/go.mod", "serviceB/go.mod"},
+			expected: map[string]Status{
+				"serviceA": StatusUpdated,
+				"serviceB": StatusUpdated,
+			},
+		},
+		{
+			input: []fileToStatus{
+				{
+					fileName: "foo/nestedServiceA/main.go", status: githubFileChangeStatusModified,
+				},
+			},
+			goModFiles: []string{"foo/nestedServiceA/go.mod"},
+			expected: map[string]Status{
+				"foo/nestedServiceA": StatusUpdated,
+			},
+		},
+		{
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/go.mod", status: githubFileChangeStatusRemoved,
+				},
+			},
+			expected: map[string]Status{
+				"serviceA": StatusDeleted,
+			},
+		},
+		{
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/go.mod", status: githubFileChangeStatusRemoved,
+				},
+				{
+					fileName: "serviceA/main.go", status: githubFileChangeStatusRemoved,
+				},
+			},
+			expected: map[string]Status{
+				"serviceA": StatusDeleted,
+			},
+		},
+		{
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/main.go", status: githubFileChangeStatusRemoved,
+				},
+			},
+			goModFiles: []string{"serviceA/go.mod"},
+			expected: map[string]Status{
+				"serviceA": StatusUpdated, // Updated not deleted because main method might not live in main.go
+			},
+		},
+	}
+	for i, tc := range tcs {
+		// set up the file system
+		appFS = afero.NewMemMapFs()
+		for _, fs := range tc.input {
+			if fs.status == githubFileChangeStatusRemoved {
+				continue
+			}
+			assert.NoError(t, appFS.MkdirAll(path.Dir(fs.fileName), 0755), "Error setting up file system for test %d", i)
+			assert.NoError(t, afero.WriteFile(appFS, fs.fileName, []byte("foobar"), 0755), "Error setting up file system for test %d", i)
+		}
+		for _, gomod := range tc.goModFiles {
+			assert.NoError(t, afero.WriteFile(appFS, gomod, []byte("foobar"), 0755), "Error setting up file system for test %d", i)
+		}
+
+		out, err := directoryStatuses(tc.input)
+		assert.NoError(t, err, "Error processing directory statuses for test %d", i)
+		assert.Equal(t, tc.expected, out, "Failed test case %d", i)
+	}
+
+}

--- a/changedetector/changedetector_test.go
+++ b/changedetector/changedetector_test.go
@@ -94,6 +94,35 @@ func TestFolderStatuses(t *testing.T) {
 				"serviceA": StatusDeleted,
 			},
 		},
+		{ // this is what a rename of the whole service should look like
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/main.go", status: githubFileChangeStatusRemoved,
+				},
+				{
+					fileName: "serviceARenamed/main.go", status: githubFileChangeStatusCreated,
+				},
+			},
+			expected: map[string]Status{
+				"serviceA":        StatusDeleted,
+				"serviceARenamed": StatusCreated,
+			},
+		},
+		{ // this is what a rename of a single file, not including the main.go, should look like
+			input: []fileToStatus{
+				{
+					fileName: "serviceA/types/types.go", status: githubFileChangeStatusRemoved,
+				},
+				{
+					fileName: "serviceB/types/types.go", status: githubFileChangeStatusCreated,
+				},
+			},
+			goMainFiles: []string{"serviceA/main.go", "serviceB/main.go"},
+			expected: map[string]Status{
+				"serviceA": StatusUpdated,
+				"serviceB": StatusUpdated,
+			},
+		},
 	}
 	for i, tc := range tcs {
 		// set up the file system

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/jhoonb/archivex v0.0.0-20180718040744-0488e4ce1681
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/afero v1.2.2
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd // indirect
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
@@ -19,6 +21,13 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -28,5 +37,9 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
- using main.go as root folder of a service so now we allow much deeper nesting of services rather than just first two levels. 
- rebuilds everything when m3o.yaml is added
- adds support for files that are renamed so we can delete/create as appropriate